### PR TITLE
Remove scrollbars when printing Income vs Expense.

### DIFF
--- a/src/extension/features/general/printing-improvements/index.css
+++ b/src/extension/features/general/printing-improvements/index.css
@@ -238,3 +238,11 @@
 	}
 
 }
+
+/* ======== Toolkit Reports -> Income vs Expense	Printing Improvements ======== */
+@media print {
+	/* Hide Scrollbars when printing income vs expense reports. */
+	.tk-overflow-scroll::-webkit-scrollbar {
+		display: none;
+	}
+}


### PR DESCRIPTION
The scrollbars get in the way when printing on A2 paper.

**Explanation of Bugfix/Feature/Modification:**
Update print.css to hide scrollbars on income vs expense report.

Tested: Chrome print to PDF on A2 landscape paper.
